### PR TITLE
Add fallback object if an organization unit does not have emissions

### DIFF
--- a/backend/src/api/reporting-period/controllers/reporting-period.ts
+++ b/backend/src/api/reporting-period/controllers/reporting-period.ts
@@ -285,7 +285,12 @@ export default factories.createCoreController(
       const unitsWithEmissions = organizationUnits.map((unit) => {
         return {
           ...unit,
-          emissions: emissionsByUnitAndSource[unit.id],
+          emissions: emissionsByUnitAndSource[unit.id] ?? {
+            scope1: [],
+            scope2: [],
+            scope3: [],
+            biogenic: [],
+          },
         };
       });
 


### PR DESCRIPTION
Closes #81 

## Description

http://localhost:1337/api/reporting-periods/1/emissions?locale=en

If there are no emission entries, this returns a 500 error. The error remains even if emission entries are later added again.

The PR fixes this bug.

## How to test

- [x] If there are one or more organization units that don't have emissions, this error is not returned anymore.
- [x] Instead, the emissions object includes an empty array for each scope.

```json
{
  "id": 2,
  "name": "Tartu campus",
  "createdAt": "2023-04-14T04:28:06.848Z",
  "updatedAt": "2023-06-16T19:47:01.351Z",
  "emissions": {
    "scope1": [],
    "scope2": [],
    "scope3": [],
    "biogenic": []
  }
}

```