### PR TITLE
Add unit to emission category with emission factors

### DIFF
--- a/backend/src/api/emission-category/controllers/emission-category.ts
+++ b/backend/src/api/emission-category/controllers/emission-category.ts
@@ -120,6 +120,7 @@ export default factories.createCoreController(
             ...source,
             factors: json.emission_sources[source.apiId]?.factors,
             label: json.emission_sources[source.apiId]?.label,
+            unit: json.emission_sources[source.apiId]?.unit,
           };
         });
 


### PR DESCRIPTION
Closes #80 

## Description

Get one emission category with emission factors:
http://localhost:1337/api/emission-categories/4/with-emission-factors?reportingPeriod=1

The objects in the emissionSources array in the returned data do not include the unit of the emission source. This is a bug, pass the unit from the emission source data.

The PR fixes this bug.

## How to test

- [x] The emission sources now include the `unit`