### PR TITLE
93/export translations as csv

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -80,7 +80,7 @@ $RECYCLE.BIN/
 ssl
 .idea
 nbproject
-public/uploads/*
+public/uploads*/*
 !public/uploads/.gitkeep
 
 ############################

--- a/backend/config/sync/admin-role.strapi-super-admin.json
+++ b/backend/config/sync/admin-role.strapi-super-admin.json
@@ -17,7 +17,7 @@
           "color",
           "quantityLabel"
         ],
-        "locales": ["en", "fi"]
+        "locales": ["en", "et"]
       },
       "conditions": []
     },
@@ -25,30 +25,12 @@
       "action": "plugin::content-manager.explorer.delete",
       "subject": "api::emission-category.emission-category",
       "properties": {
-        "locales": ["en", "fi"]
+        "locales": ["en", "et"]
       },
       "conditions": []
     },
     {
       "action": "plugin::content-manager.explorer.read",
-      "subject": "api::emission-category.emission-category",
-      "properties": {
-        "fields": [
-          "title",
-          "description",
-          "emissionGroup",
-          "emissionSources",
-          "primaryScope",
-          "emissionSourceLabel",
-          "color",
-          "quantityLabel"
-        ],
-        "locales": ["en", "fi"]
-      },
-      "conditions": []
-    },
-    {
-      "action": "plugin::content-manager.explorer.update",
       "subject": "api::emission-category.emission-category",
       "properties": {
         "fields": [
@@ -61,7 +43,25 @@
           "color",
           "quantityLabel"
         ],
-        "locales": ["en", "fi"]
+        "locales": ["en", "et"]
+      },
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.update",
+      "subject": "api::emission-category.emission-category",
+      "properties": {
+        "fields": [
+          "title",
+          "description",
+          "emissionGroup",
+          "emissionSources",
+          "primaryScope",
+          "emissionSourceLabel",
+          "color",
+          "quantityLabel"
+        ],
+        "locales": ["en", "et"]
       },
       "conditions": []
     },
@@ -169,7 +169,7 @@
       "subject": "api::emission-factor-datum.emission-factor-datum",
       "properties": {
         "fields": ["json", "dataset", "year"],
-        "locales": ["en", "fi"]
+        "locales": ["en", "et"]
       },
       "conditions": []
     },
@@ -177,7 +177,7 @@
       "action": "plugin::content-manager.explorer.delete",
       "subject": "api::emission-factor-datum.emission-factor-datum",
       "properties": {
-        "locales": ["en", "fi"]
+        "locales": ["en", "et"]
       },
       "conditions": []
     },
@@ -186,7 +186,7 @@
       "subject": "api::emission-factor-datum.emission-factor-datum",
       "properties": {
         "fields": ["json", "dataset", "year"],
-        "locales": ["en", "fi"]
+        "locales": ["en", "et"]
       },
       "conditions": []
     },
@@ -195,7 +195,7 @@
       "subject": "api::emission-factor-datum.emission-factor-datum",
       "properties": {
         "fields": ["json", "dataset", "year"],
-        "locales": ["en", "fi"]
+        "locales": ["en", "et"]
       },
       "conditions": []
     },
@@ -204,7 +204,7 @@
       "subject": "api::emission-group.emission-group",
       "properties": {
         "fields": ["title", "emissionCategories"],
-        "locales": ["en", "fi"]
+        "locales": ["en", "et"]
       },
       "conditions": []
     },
@@ -212,7 +212,7 @@
       "action": "plugin::content-manager.explorer.delete",
       "subject": "api::emission-group.emission-group",
       "properties": {
-        "locales": ["en", "fi"]
+        "locales": ["en", "et"]
       },
       "conditions": []
     },
@@ -221,7 +221,7 @@
       "subject": "api::emission-group.emission-group",
       "properties": {
         "fields": ["title", "emissionCategories"],
-        "locales": ["en", "fi"]
+        "locales": ["en", "et"]
       },
       "conditions": []
     },
@@ -230,7 +230,7 @@
       "subject": "api::emission-group.emission-group",
       "properties": {
         "fields": ["title", "emissionCategories"],
-        "locales": ["en", "fi"]
+        "locales": ["en", "et"]
       },
       "conditions": []
     },
@@ -239,7 +239,7 @@
       "subject": "api::emission-source-group.emission-source-group",
       "properties": {
         "fields": ["name", "emissionSourceLabel", "quantityLabel"],
-        "locales": ["en", "fi"]
+        "locales": ["en", "et"]
       },
       "conditions": []
     },
@@ -247,7 +247,7 @@
       "action": "plugin::content-manager.explorer.delete",
       "subject": "api::emission-source-group.emission-source-group",
       "properties": {
-        "locales": ["en", "fi"]
+        "locales": ["en", "et"]
       },
       "conditions": []
     },
@@ -256,7 +256,7 @@
       "subject": "api::emission-source-group.emission-source-group",
       "properties": {
         "fields": ["name", "emissionSourceLabel", "quantityLabel"],
-        "locales": ["en", "fi"]
+        "locales": ["en", "et"]
       },
       "conditions": []
     },
@@ -265,7 +265,7 @@
       "subject": "api::emission-source-group.emission-source-group",
       "properties": {
         "fields": ["name", "emissionSourceLabel", "quantityLabel"],
-        "locales": ["en", "fi"]
+        "locales": ["en", "et"]
       },
       "conditions": []
     },
@@ -481,7 +481,7 @@
       "subject": "api::settings-dashboard.settings-dashboard",
       "properties": {
         "fields": ["emissionCategories"],
-        "locales": ["en", "fi"]
+        "locales": ["en", "et"]
       },
       "conditions": []
     },
@@ -489,7 +489,7 @@
       "action": "plugin::content-manager.explorer.delete",
       "subject": "api::settings-dashboard.settings-dashboard",
       "properties": {
-        "locales": ["en", "fi"]
+        "locales": ["en", "et"]
       },
       "conditions": []
     },
@@ -498,7 +498,7 @@
       "subject": "api::settings-dashboard.settings-dashboard",
       "properties": {
         "fields": ["emissionCategories"],
-        "locales": ["en", "fi"]
+        "locales": ["en", "et"]
       },
       "conditions": []
     },
@@ -507,7 +507,7 @@
       "subject": "api::settings-dashboard.settings-dashboard",
       "properties": {
         "fields": ["emissionCategories"],
-        "locales": ["en", "fi"]
+        "locales": ["en", "et"]
       },
       "conditions": []
     },
@@ -524,7 +524,7 @@
           "landingPageLink.label",
           "landingPageLink.url"
         ],
-        "locales": ["en", "fi"]
+        "locales": ["en", "et"]
       },
       "conditions": []
     },
@@ -532,7 +532,7 @@
       "action": "plugin::content-manager.explorer.delete",
       "subject": "api::settings-general.settings-general",
       "properties": {
-        "locales": ["en", "fi"]
+        "locales": ["en", "et"]
       },
       "conditions": []
     },
@@ -549,7 +549,7 @@
           "landingPageLink.label",
           "landingPageLink.url"
         ],
-        "locales": ["en", "fi"]
+        "locales": ["en", "et"]
       },
       "conditions": []
     },
@@ -566,7 +566,7 @@
           "landingPageLink.label",
           "landingPageLink.url"
         ],
-        "locales": ["en", "fi"]
+        "locales": ["en", "et"]
       },
       "conditions": []
     },
@@ -575,7 +575,7 @@
       "subject": "api::translation.translation",
       "properties": {
         "fields": ["key", "translation"],
-        "locales": ["en", "fi"]
+        "locales": ["en", "et"]
       },
       "conditions": []
     },
@@ -583,7 +583,7 @@
       "action": "plugin::content-manager.explorer.delete",
       "subject": "api::translation.translation",
       "properties": {
-        "locales": ["en", "fi"]
+        "locales": ["en", "et"]
       },
       "conditions": []
     },
@@ -592,7 +592,7 @@
       "subject": "api::translation.translation",
       "properties": {
         "fields": ["key", "translation"],
-        "locales": ["en", "fi"]
+        "locales": ["en", "et"]
       },
       "conditions": []
     },
@@ -601,7 +601,7 @@
       "subject": "api::translation.translation",
       "properties": {
         "fields": ["key", "translation"],
-        "locales": ["en", "fi"]
+        "locales": ["en", "et"]
       },
       "conditions": []
     },

--- a/backend/config/sync/core-store.plugin_content_manager_configuration_content_types##api##emission-factor-datum.emission-factor-datum.json
+++ b/backend/config/sync/core-store.plugin_content_manager_configuration_content_types##api##emission-factor-datum.emission-factor-datum.json
@@ -26,7 +26,7 @@
           "description": "",
           "placeholder": "",
           "visible": true,
-          "editable": false
+          "editable": true
         },
         "list": {
           "label": "json",

--- a/backend/config/sync/i18n-locale.et.json
+++ b/backend/config/sync/i18n-locale.et.json
@@ -1,0 +1,4 @@
+{
+  "name": "Estonian (et)",
+  "code": "et"
+}

--- a/backend/config/sync/i18n-locale.fi.json
+++ b/backend/config/sync/i18n-locale.fi.json
@@ -1,4 +1,0 @@
-{
-  "name": "Finnish (fi)",
-  "code": "fi"
-}

--- a/backend/config/sync/user-role.authenticated.json
+++ b/backend/config/sync/user-role.authenticated.json
@@ -115,6 +115,9 @@
       "action": "api::settings-general.settings-general.find"
     },
     {
+      "action": "api::translation.translation.exportTranslations"
+    },
+    {
       "action": "api::translation.translation.find"
     },
     {

--- a/backend/config/sync/user-role.public.json
+++ b/backend/config/sync/user-role.public.json
@@ -43,6 +43,9 @@
       "action": "api::settings-general.settings-general.find"
     },
     {
+      "action": "api::translation.translation.exportTranslations"
+    },
+    {
       "action": "api::translation.translation.find"
     },
     {

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -15,8 +15,12 @@
         "@types/koa": "^2.13.6",
         "better-sqlite3": "8.0.1",
         "date-fns": "^2.30.0",
+        "papaparse": "^5.4.1",
         "strapi-plugin-config-sync": "^1.1.1",
         "yup": "^1.2.0"
+      },
+      "devDependencies": {
+        "@types/papaparse": "^5.3.8"
       },
       "engines": {
         "node": ">=14.19.1 <=18.x.x",
@@ -3286,6 +3290,15 @@
       "version": "18.15.11",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.11.tgz",
       "integrity": "sha512-E5Kwq2n4SbMzQOn6wnmBjuK9ouqlURrcZDVfbo9ftDDTFt3nk7ZKK4GMOzoYgnpQJKcxwQw+lGaBvvlMo0qN/Q=="
+    },
+    "node_modules/@types/papaparse": {
+      "version": "5.3.8",
+      "resolved": "https://registry.npmjs.org/@types/papaparse/-/papaparse-5.3.8.tgz",
+      "integrity": "sha512-ArKIEOOWULbhi53wkAiRy1ze4wvrTfhpAj7Yfzva+EkmX2sV8PpFB+xqzJfzXNzK4me95FJH9QZt5NXFVGzOoQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/parse-json": {
       "version": "4.0.0",
@@ -10334,6 +10347,11 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/papaparse": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/papaparse/-/papaparse-5.4.1.tgz",
+      "integrity": "sha512-HipMsgJkZu8br23pW15uvo6sib6wne/4woLZPlFf3rpDyMe9ywEXUsuD7+6K9PRkJlVT51j/sCOYDKGGS3ZJrw=="
     },
     "node_modules/param-case": {
       "version": "3.0.4",

--- a/backend/package.json
+++ b/backend/package.json
@@ -22,6 +22,7 @@
     "@types/koa": "^2.13.6",
     "better-sqlite3": "8.0.1",
     "date-fns": "^2.30.0",
+    "papaparse": "^5.4.1",
     "strapi-plugin-config-sync": "^1.1.1",
     "yup": "^1.2.0"
   },
@@ -35,5 +36,8 @@
     "node": ">=14.19.1 <=18.x.x",
     "npm": ">=6.0.0"
   },
-  "license": "MIT"
+  "license": "MIT",
+  "devDependencies": {
+    "@types/papaparse": "^5.3.8"
+  }
 }

--- a/backend/src/api/translation/controllers/translation.ts
+++ b/backend/src/api/translation/controllers/translation.ts
@@ -3,5 +3,103 @@
  */
 
 import { factories } from "@strapi/strapi";
+import utils from "@strapi/utils";
+import * as yup from "yup";
+import { validate } from "../../../services/utils";
+import { TranslatableEntry, TranslationService } from "../services/translation";
 
-export default factories.createCoreController("api::translation.translation");
+const { ApplicationError, ValidationError } = utils.errors;
+
+interface ExportableAttributes {
+  uid: string;
+  id: number;
+  attribute: string;
+  value_en: string;
+}
+
+/**
+ * Convert a content entry to an array of exportable attributes
+ * @param entry {TranslatableEntry} The entry to convert
+ * @returns {ExportableAttributes[]}
+ */
+const convertEntryToExportableAttributes = (
+  entry: TranslatableEntry
+): ExportableAttributes[] => {
+  // TODO
+  return [];
+};
+
+/**
+ * Convert a JSON-compliant JavaScript array of objects to a specified data format
+ * @param input {object[]} And array of objects to convert
+ * @param format {string} The output format
+ * @returns {string} The converted output
+ */
+const convertJsonTo = (input: object[], format: string): string => {
+  // TODO
+  return "";
+};
+
+export default factories.createCoreController(
+  "api::translation.translation",
+  ({ strapi }) => ({
+    async exportTranslations(ctx) {
+      // Validate request and extract typed arguments
+      const { as } = await validate(
+        ctx.query,
+        yup.object({ as: yup.string().required().oneOf(["csv"]) }),
+        ValidationError
+      );
+
+      // For each translatable uid, collect each translatable attribute
+      const translatableUids = [
+        "api:::emission-category.emission-category",
+        "api:::emission-group.emission-group",
+        "api:::emission-source-group.emission-source-group",
+        "api:::translation.translation",
+        "api:::settings-general.settings-general",
+      ];
+
+      const getTranslatableContentType = strapi.service<TranslationService>(
+        "api::translation.translation"
+      )?.getTranslatableContentType;
+
+      if (!getTranslatableContentType)
+        throw new ApplicationError(
+          "getTranslatableContentType service not available"
+        );
+
+      const translatableContentTypes = await Promise.all(
+        translatableUids.map(getTranslatableContentType)
+      );
+
+      // Find all entries of each translatable content type, selecting/populating the translatable attributes
+      const getTranslatableEntries = strapi.service<TranslationService>(
+        "api::translation.translation"
+      )?.getTranslatableEntries;
+
+      if (!getTranslatableEntries)
+        throw new ApplicationError(
+          "getTranslatableEntries service not available"
+        );
+
+      const translatableEntries = (
+        await Promise.all(
+          translatableUids.map((uid) =>
+            getTranslatableEntries(uid, translatableContentTypes[uid])
+          )
+        )
+      ).flatMap((_) => _);
+
+      // Loop through each entry's each attribute and build the exportable array of objects
+      const translatableAttributes = translatableEntries.flatMap(
+        convertEntryToExportableAttributes
+      );
+
+      // Transfer the json to csv and initiate a download
+      const output = convertJsonTo(translatableAttributes, as);
+
+      return output;
+    },
+  })
+);

--- a/backend/src/api/translation/routes/01-custom-translation.ts
+++ b/backend/src/api/translation/routes/01-custom-translation.ts
@@ -1,0 +1,9 @@
+export default {
+  routes: [
+    {
+      method: "GET",
+      path: "/translations/export",
+      handler: "translation.exportTranslations",
+    },
+  ],
+};

--- a/backend/src/api/translation/services/translation.ts
+++ b/backend/src/api/translation/services/translation.ts
@@ -3,33 +3,55 @@
  */
 
 import { factories } from "@strapi/strapi";
-import { LocalizedApiServiceEntry } from "../../api.types";
 
-interface TranslatableContentType {
-  kind: "collectionType" | "singleType";
+export interface TranslatableContentType {
+  uid: string;
+  kind: string;
   attributes: {
     [key: string]: {
-      type: "string" | "richtext" | "component";
+      type: string;
     };
   };
 }
 
-interface TranslatableComponent {
+interface ContentType {
+  kind: string;
+  attributes: {
+    [key: string]: {
+      type: string;
+      pluginOptions?: {
+        i18n?: {
+          localized: boolean;
+        };
+      };
+    };
+  };
+}
+
+export interface TranslatableComponent {
   [key: string]: string;
 }
 
-export type TranslatableEntry = {
-  [key: string]: string | TranslatableComponent;
+export interface TranslatableAttributes {
+  [key: string]: string | TranslatableComponent | null;
+}
+
+export type TranslatableEntry = TranslatableAttributes & {
+  id: number;
 };
 
+export interface TranslatableEntryOutput {
+  uid: string;
+  id: number;
+  attributes: TranslatableAttributes;
+}
+
 export type TranslationService = {
-  getTranslatableContentType(
-    uid: string
-  ): Promise<TranslatableContentType | null>;
+  getTranslatableContentType(uid: string): TranslatableContentType | null;
   getTranslatableEntries(
     uid: string,
     schema: TranslatableContentType
-  ): Promise<TranslatableEntry[]>;
+  ): Promise<TranslatableEntryOutput[]>;
 };
 
 export default factories.createCoreService<
@@ -41,19 +63,56 @@ export default factories.createCoreService<
    * @param uid {string} The Strapi uid of the content type
    * @returns {Promise<TranslatableContentType|null>} depending on whether a content type was found for the uid or not
    */
-  async getTranslatableContentType(uid) {
-    // TODO
-    return null;
+  getTranslatableContentType(uid) {
+    const contentType = strapi.contentTypes[uid] as ContentType | undefined;
+
+    if (!contentType) return null;
+
+    const { kind, attributes } = contentType;
+
+    const translatableAttributes = Object.fromEntries(
+      Object.entries(attributes)
+        .filter(([_, { pluginOptions }]) => pluginOptions?.i18n?.localized)
+        .map(([key, { type }]) => [key, { type }])
+    );
+
+    return { uid, kind, attributes: translatableAttributes };
   },
 
   /**
    * Get translatable entries of a content type
    * @param uid {string} The Strapi uid of the content type
    * @param schema {TranslatableContentType} The translatable content type schema
-   * @returns {Promise<TranslatableEntry[]>}
+   * @returns {Promise<TranslatableEntryOutput[]>}
    */
   async getTranslatableEntries(uid, schema) {
-    // TODO
-    return [];
+    const { fields, populate } = Object.entries(schema.attributes).reduce<{
+      fields: string[];
+      populate: string[];
+    }>(
+      ({ fields, populate }, [key, { type }]) => {
+        if (type === "component")
+          return { fields, populate: [...populate, key] };
+        return { fields: [...fields, key], populate };
+      },
+      { fields: [], populate: [] }
+    );
+
+    const entries: TranslatableEntry | TranslatableEntry[] =
+      await strapi.entityService.findMany(uid, {
+        fields,
+        populate,
+      });
+
+    // Convert single types to array to enable mapping
+    const entriesArr = Array.isArray(entries) ? entries : [entries];
+
+    const output = entriesArr.map(({ id, ...attributes }) => ({
+      uid,
+      id,
+      attributes,
+    }));
+
+    return output;
   },
 }));

--- a/backend/src/api/translation/services/translation.ts
+++ b/backend/src/api/translation/services/translation.ts
@@ -3,5 +3,57 @@
  */
 
 import { factories } from "@strapi/strapi";
+import { LocalizedApiServiceEntry } from "../../api.types";
 
-export default factories.createCoreService("api::translation.translation");
+interface TranslatableContentType {
+  kind: "collectionType" | "singleType";
+  attributes: {
+    [key: string]: {
+      type: "string" | "richtext" | "component";
+    };
+  };
+}
+
+interface TranslatableComponent {
+  [key: string]: string;
+}
+
+export type TranslatableEntry = {
+  [key: string]: string | TranslatableComponent;
+};
+
+export type TranslationService = {
+  getTranslatableContentType(
+    uid: string
+  ): Promise<TranslatableContentType | null>;
+  getTranslatableEntries(
+    uid: string,
+    schema: TranslatableContentType
+  ): Promise<TranslatableEntry[]>;
+};
+
+export default factories.createCoreService<
+  "api::translation.translation",
+  TranslationService
+>("api::translation.translation", ({ strapi }) => ({
+  /**
+   * Get a translatable content type by Strapi uid
+   * @param uid {string} The Strapi uid of the content type
+   * @returns {Promise<TranslatableContentType|null>} depending on whether a content type was found for the uid or not
+   */
+  async getTranslatableContentType(uid) {
+    // TODO
+    return null;
+  },
+
+  /**
+   * Get translatable entries of a content type
+   * @param uid {string} The Strapi uid of the content type
+   * @param schema {TranslatableContentType} The translatable content type schema
+   * @returns {Promise<TranslatableEntry[]>}
+   */
+  async getTranslatableEntries(uid, schema) {
+    // TODO
+    return [];
+  },
+}));

--- a/backend/yarn.lock
+++ b/backend/yarn.lock
@@ -1705,6 +1705,13 @@
   resolved "https://registry.npmjs.org/@types/node/-/node-18.15.11.tgz"
   integrity sha512-E5Kwq2n4SbMzQOn6wnmBjuK9ouqlURrcZDVfbo9ftDDTFt3nk7ZKK4GMOzoYgnpQJKcxwQw+lGaBvvlMo0qN/Q==
 
+"@types/papaparse@^5.3.8":
+  version "5.3.8"
+  resolved "https://registry.npmjs.org/@types/papaparse/-/papaparse-5.3.8.tgz"
+  integrity sha512-ArKIEOOWULbhi53wkAiRy1ze4wvrTfhpAj7Yfzva+EkmX2sV8PpFB+xqzJfzXNzK4me95FJH9QZt5NXFVGzOoQ==
+  dependencies:
+    "@types/node" "*"
+
 "@types/parse-json@^4.0.0":
   version "4.0.0"
   resolved "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz"
@@ -6554,6 +6561,11 @@ package-json@7.0.0:
     registry-auth-token "^4.0.0"
     registry-url "^5.0.0"
     semver "^7.3.5"
+
+papaparse@^5.4.1:
+  version "5.4.1"
+  resolved "https://registry.npmjs.org/papaparse/-/papaparse-5.4.1.tgz"
+  integrity sha512-HipMsgJkZu8br23pW15uvo6sib6wne/4woLZPlFf3rpDyMe9ywEXUsuD7+6K9PRkJlVT51j/sCOYDKGGS3ZJrw==
 
 param-case@^2.1.0:
   version "2.1.1"


### PR DESCRIPTION
Closes #93 

## Description

Implements a custom API endpoint `GET /api/translations/export?as=csv` for exporting all translatable strings as CSV.

## How to test

```bash
npm i
npm run cs i
npm run develop
```

- [ ] Go to http://localhost:1337/api/translations/export?as=csv in your browser. It should trigger a csv download.
- [ ] Import the csv to Excel or Google Sheets. The data should have the columns `uid`, `id`, `attribute` and `value_en`
- [ ] The values look correct